### PR TITLE
Add etherscan link to transaction overview

### DIFF
--- a/src/components/TransactionsTable.jsx
+++ b/src/components/TransactionsTable.jsx
@@ -60,8 +60,9 @@ const TransactionsTable = () => {
                           { transaction.blockNumber === 'pending' ? 'Pending' : 'Confirmed' }
                         </span>
                         <span>
-                          <a target="_blank" rel="noopener noreferrer" href={buildLink(chainId, transaction.transactionHash, 'transaction')}>
-                            View transaction
+                          <a className="transaction-link" target="_blank" rel="noopener noreferrer" href={buildLink(chainId, transaction.transactionHash, 'transaction')}>
+                            View transaction&nbsp;
+                            <span role="img" aria-label="link">🔗</span>
                           </a>
                         </span>
                       </div>

--- a/src/components/TransactionsTable.jsx
+++ b/src/components/TransactionsTable.jsx
@@ -1,12 +1,14 @@
 import React from 'react';
 
 import { view } from 'react-easy-state';
+import { useWeb3React } from '@web3-react/core';
 
 import amountFormatter from '../utils/amountFormatter';
 import ConnectWeb3Button from './ConnectWeb3Button';
 import Identicon from './Identicon';
 import If from './If';
 import myAccount from '../stores/myAccount';
+import { buildLink } from '../utils/etherscan';
 
 const formatTimestamp = (timestamp) => (new Date(timestamp * 1000)).toUTCString();
 const transactionName = ({ direction }) => (
@@ -21,6 +23,7 @@ const transactionUSDValue = ({ direction, daiAmount }) => (
 
 const TransactionsTable = () => {
   const transactions = (myAccount.awpTransactions || []).sort((a, b) => b.timestamp - a.timestamp);
+  const { chainId } = useWeb3React();
   const count = transactions.length;
 
   if (count === 0) {
@@ -55,6 +58,11 @@ const TransactionsTable = () => {
                       <div className="state">
                         <span className="color-label">
                           { transaction.blockNumber === 'pending' ? 'Pending' : 'Confirmed' }
+                        </span>
+                        <span>
+                          <a target="_blank" rel="noopener noreferrer" href={buildLink(chainId, transaction.transactionHash, 'transaction')}>
+                            View transaction
+                          </a>
                         </span>
                       </div>
                       <div className="usd-value">{transactionUSDValue(transaction)}</div>

--- a/src/components/TransactionsTable.jsx
+++ b/src/components/TransactionsTable.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import { view } from 'react-easy-state';
-import { useWeb3React } from '@web3-react/core';
 
 import amountFormatter from '../utils/amountFormatter';
 import ConnectWeb3Button from './ConnectWeb3Button';
@@ -9,6 +8,7 @@ import Identicon from './Identicon';
 import If from './If';
 import myAccount from '../stores/myAccount';
 import { buildLink } from '../utils/etherscan';
+import eth from '../stores/eth';
 
 const formatTimestamp = (timestamp) => (new Date(timestamp * 1000)).toUTCString();
 const transactionName = ({ direction }) => (
@@ -23,7 +23,7 @@ const transactionUSDValue = ({ direction, daiAmount }) => (
 
 const TransactionsTable = () => {
   const transactions = (myAccount.awpTransactions || []).sort((a, b) => b.timestamp - a.timestamp);
-  const { chainId } = useWeb3React();
+  const { networkId } = eth;
   const count = transactions.length;
 
   if (count === 0) {
@@ -60,7 +60,7 @@ const TransactionsTable = () => {
                           { transaction.blockNumber === 'pending' ? 'Pending' : 'Confirmed' }
                         </span>
                         <span>
-                          <a className="transaction-link" target="_blank" rel="noopener noreferrer" href={buildLink(chainId, transaction.transactionHash, 'transaction')}>
+                          <a className="transaction-link" target="_blank" rel="noopener noreferrer" href={buildLink(networkId, transaction.transactionHash, 'transaction')}>
                             View transaction&nbsp;
                             <span role="img" aria-label="link">🔗</span>
                           </a>

--- a/src/styles.css
+++ b/src/styles.css
@@ -871,6 +871,14 @@ p.Ptab {
   @apply w-100pc;
 }
 
+.transaction-link {
+  @apply ml-10px;
+}
+
+.transaction-link:hover {
+  opacity: 0.8;
+}
+
 .transactions-table-container .transaction .bottom {
   @apply w-100pc flex flex-row items-center mt-10px;
 }


### PR DESCRIPTION
##### Description
<!-- A description on what this PR aims to solve. -->
Adds a link to the transactions in the overview so users can inspect their transactions on Etherscan

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Changes don't break existing behavior
- [ ] Tests coverage hasn't decreased

##### Testing
<!-- Why should the PR reviewer trust that this change doesn't break
  anything? How have you tested this change?
-->
Go to the portfolio page and click the tx link.

##### Refers/Fixes
<!--
  Link to an issue if applicable. For example:
  If your PR fixes an issue -- Fixes: #102
  If your PR refers an issue -- Refs: #101
-->
#54 